### PR TITLE
Remove call to screen_icon

### DIFF
--- a/admin/class-theme-my-login-admin.php
+++ b/admin/class-theme-my-login-admin.php
@@ -135,7 +135,6 @@ class Theme_My_Login_Admin extends Theme_My_Login_Abstract {
 		) ) );
 		?>
 		<div id="<?php echo $options_key; ?>" class="wrap">
-			<?php screen_icon( 'options-general' ); ?>
 			<h2><?php echo esc_html( $title ); ?></h2>
 			<?php settings_errors(); ?>
 

--- a/modules/custom-email/admin/custom-email-admin.php
+++ b/modules/custom-email/admin/custom-email-admin.php
@@ -146,7 +146,6 @@ class Theme_My_Login_Custom_Email_Admin extends Theme_My_Login_Abstract {
 		global $current_screen;
 		?>
 		<div class="wrap">
-			<?php screen_icon( 'options-general' ); ?>
 			<h2><?php echo esc_html_e( 'Theme My Login Custom E-mail Settings', 'theme-my-login' ); ?></h2>
 			<?php settings_errors(); ?>
 

--- a/modules/custom-redirection/admin/custom-redirection-admin.php
+++ b/modules/custom-redirection/admin/custom-redirection-admin.php
@@ -130,7 +130,6 @@ class Theme_My_Login_Custom_Redirection_Admin extends Theme_My_Login_Abstract {
 		global $current_screen;
 		?>
 		<div class="wrap">
-			<?php screen_icon( 'options-general' ); ?>
 			<h2><?php echo esc_html_e( 'Theme My Login Custom Redirection Settings', 'theme-my-login' ); ?></h2>
 			<?php settings_errors(); ?>
 

--- a/modules/custom-user-links/admin/custom-user-links-admin.php
+++ b/modules/custom-user-links/admin/custom-user-links-admin.php
@@ -141,7 +141,6 @@ class Theme_My_Login_Custom_User_Links_Admin extends Theme_My_Login_Abstract {
 		global $current_screen;
 		?>
 		<div class="wrap">
-			<?php screen_icon( 'options-general' ); ?>
 			<h2><?php echo esc_html_e( 'Theme My Login Custom User Links Settings', 'theme-my-login' ); ?></h2>
 			<?php settings_errors(); ?>
 


### PR DESCRIPTION
Screen icons are no longer used as of WordPress 3.8
