### PR TITLE
Fix language files not loading properly.

### DIFF
--- a/includes/class-theme-my-login.php
+++ b/includes/class-theme-my-login.php
@@ -134,6 +134,7 @@ class Theme_My_Login extends Theme_My_Login_Abstract {
 
 		add_action( 'plugins_loaded',          array( &$this, 'plugins_loaded'          ) );
 		add_action( 'init',                    array( &$this, 'init'                    ) );
+		add_action( 'load_textdomain',         array( $this, 'load_custom_textdomain'   ), 10, 2 );
 		add_action( 'widgets_init',            array( &$this, 'widgets_init'            ) );
 		add_action( 'wp',                      array( &$this, 'wp'                      ) );
 		add_action( 'pre_get_posts',           array( &$this, 'pre_get_posts'           ) );
@@ -183,7 +184,7 @@ class Theme_My_Login extends Theme_My_Login_Abstract {
 	public function init() {
 		global $pagenow;
 
-		self::load_textdomain();
+		load_plugin_textdomain( 'theme-my-login', false, plugin_basename( THEMEMYLOGIN_PATH ) . '/language' );
 
 		$this->errors = new WP_Error();
 
@@ -1084,35 +1085,31 @@ if(typeof wpOnload=='function')wpOnload()
 	}
 
 	/**
-	 * Load the translation file for current language. Checks the languages
-	 * folder inside the plugin first, and then the default WordPress
-	 * languages folder.
+	 * Load a custom translation file for current language if available.
 	 *
 	 * Note that custom translation files inside the plugin folder
 	 * will be removed on plugin updates. If you're creating custom
-	 * translation files, please use the global language folder.
+	 * translation files, please place them in a '/theme-my-login/'
+	 * directory within the global language folder.
 	 *
-	 * @since 6.3
+	 * @since 6.4.3
 	 *
-	 * @return bool True on success, false on failure
+	 * @param string $domain The domain for which a language file is being loaded.
+	 * @param string $mofile Full path to the target mofile.
 	 */
-	private static function load_textdomain() {
+	public function load_custom_textdomain( $domain, $mofile ) {
+		if ( 'theme-my-login' === $domain ) {
+			remove_action( 'load_textdomain', array( $this, 'load_custom_textdomain' ), 10, 2 );
 
-		// Traditional WordPress plugin locale filter
-		$locale = apply_filters( 'plugin_locale',  get_locale(), 'theme-my-login' );
-		$mofile = sprintf( 'theme-my-login-%s.mo', $locale );
+			// Look in global /wp-content/languages/theme-my-login folder for a translation
+			// and load it if available.
+			$mofile = basename( $mofile );
+			if ( file_exists( WP_LANG_DIR . '/theme-my-login/' . $mofile ) ) {
+				load_textdomain( 'theme-my-login', WP_LANG_DIR . '/theme-my-login/' . $mofile );
+			}
 
-		// Look in global /wp-content/languages/theme-my-login folder
-		if ( file_exists( WP_LANG_DIR . '/theme-my-login/' . $mofile ) ) {
-			return load_textdomain( 'theme-my-login', WP_LANG_DIR . '/theme-my-login/' . $mofile );
-
-		// Look in local /wp-content/plugins/theme-my-login/language folder
-		} elseif ( file_exists( WP_PLUGIN_DIR . '/theme-my-login/language/' . $mofile ) ) {
-			return load_textdomain( 'theme-my-login', WP_PLUGIN_DIR . '/theme-my-login/language/' . $mofile );
+			add_action( 'load_textdomain', array( $this, 'load_custom_textdomain' ), 10, 2 );
 		}
-
-		// Nothing found
-		return false;
 	}
 
 	/**

--- a/theme-my-login.php
+++ b/theme-my-login.php
@@ -7,12 +7,16 @@ Version: 6.4.2
 Author: Jeff Farthing
 Author URI: http://www.jfarthing.com
 Text Domain: theme-my-login
-Domain Path: /language/
+Domain Path: /language
 */
 
 // Allow custom functions file
 if ( file_exists( WP_PLUGIN_DIR . '/theme-my-login-custom.php' ) )
 	include_once( WP_PLUGIN_DIR . '/theme-my-login-custom.php' );
+
+if ( ! defined( 'THEMEMYLOGIN_PATH' ) ) {
+	define( 'THEMEMYLOGIN_PATH', dirname( __FILE__ ) );
+}
 
 // Require a few needed files
 require_once( WP_PLUGIN_DIR . '/theme-my-login/includes/class-theme-my-login-common.php' );


### PR DESCRIPTION
For one of the 100% translated languages, the language string were not being loaded properly. This PR fixes that.

Compatible with the GlotPress translations as well as the 'old' way of having a customized language file in `wp-content/languages/theme-my-login/`.
