### PR TITLE
Fix file loading for non-standard directory setups.

### DIFF
--- a/admin/class-theme-my-login-admin.php
+++ b/admin/class-theme-my-login-admin.php
@@ -54,7 +54,7 @@ class Theme_My_Login_Admin extends Theme_My_Login_Abstract {
 		add_action( 'admin_menu', array( &$this, 'admin_menu' ), 8 );
 		add_action( 'admin_enqueue_scripts', array( &$this, 'admin_enqueue_scripts' ), 11 );
 
-		register_uninstall_hook( WP_PLUGIN_DIR . '/theme-my-login/theme-my-login.php', array( 'Theme_My_Login_Admin', 'uninstall' ) );
+		register_uninstall_hook( THEMEMYLOGIN_PATH . '/theme-my-login.php', array( 'Theme_My_Login_Admin', 'uninstall' ) );
 	}
 
 	/**
@@ -116,7 +116,7 @@ class Theme_My_Login_Admin extends Theme_My_Login_Abstract {
 	 * @access public
 	 */
 	public function admin_enqueue_scripts() {
-		wp_enqueue_script( 'theme-my-login-admin', plugins_url( 'theme-my-login/admin/js/theme-my-login-admin.js' ), array( 'jquery' ), Theme_My_Login::VERSION, true );
+		wp_enqueue_script( 'theme-my-login-admin', plugins_url( 'js/theme-my-login-admin.js', __FILE__ ), array( 'jquery' ), Theme_My_Login::VERSION, true );
 		wp_localize_script( 'theme-my-login-admin', 'tmlAdmin', array(
 			'interim_login_url' => site_url( 'wp-login.php?interim-login=1', 'login' )
 		) );
@@ -227,8 +227,8 @@ class Theme_My_Login_Admin extends Theme_My_Login_Abstract {
 		// If we have modules to activate
 		if ( $activate = array_diff( $settings['active_modules'], $this->get_option( 'active_modules', array() ) ) ) {
 			foreach ( $activate as $module ) {
-				if ( file_exists( WP_PLUGIN_DIR . '/theme-my-login/modules/' . $module ) )
-					include_once( WP_PLUGIN_DIR . '/theme-my-login/modules/' . $module );
+				if ( file_exists( THEMEMYLOGIN_PATH . '/modules/' . $module ) )
+					include_once( THEMEMYLOGIN_PATH . '/modules/' . $module );
 				do_action( 'tml_activate_' . $module );
 			}
 		}
@@ -345,8 +345,8 @@ class Theme_My_Login_Admin extends Theme_My_Login_Abstract {
 
 		// Activate modules
 		foreach ( $this->get_option( 'active_modules', array() ) as $module ) {
-			if ( file_exists( WP_PLUGIN_DIR . '/theme-my-login/modules/' . $module ) )
-				include_once( WP_PLUGIN_DIR . '/theme-my-login/modules/' . $module );
+			if ( file_exists( THEMEMYLOGIN_PATH . '/modules/' . $module ) )
+				include_once( THEMEMYLOGIN_PATH . '/modules/' . $module );
 			do_action( 'tml_activate_' . $module );
 		}
 
@@ -391,8 +391,8 @@ class Theme_My_Login_Admin extends Theme_My_Login_Abstract {
 		foreach ( array_keys( $modules ) as $module ) {
 			$module = plugin_basename( trim( $module ) );
 
-			if ( file_exists( WP_PLUGIN_DIR . '/theme-my-login/modules/' . $module ) )
-				@include ( WP_PLUGIN_DIR . '/theme-my-login/modules/' . $module );
+			if ( file_exists( THEMEMYLOGIN_PATH . '/modules/' . $module ) )
+				@include ( THEMEMYLOGIN_PATH . '/modules/' . $module );
 
 			do_action( 'tml_uninstall_' . $module );
 		}

--- a/includes/class-theme-my-login-ms-signup.php
+++ b/includes/class-theme-my-login-ms-signup.php
@@ -485,7 +485,7 @@ class Theme_My_Login_MS_Signup extends Theme_My_Login_Abstract {
 		global $wpdb;
 		require_once ( ABSPATH . '/wp-admin/includes/plugin.php' );
 		if ( is_plugin_active_for_network( 'theme-my-login/theme-my-login.php' ) ) {
-			require_once( WP_PLUGIN_DIR . '/theme-my-login/admin/class-theme-my-login-admin.php' );
+			require_once( THEMEMYLOGIN_PATH . '/admin/class-theme-my-login-admin.php' );
 			switch_to_blog( $blog_id );
 			$admin = Theme_My_Login_Admin::get_object();
 			$admin->install();

--- a/includes/class-theme-my-login-template.php
+++ b/includes/class-theme-my-login-template.php
@@ -456,7 +456,7 @@ class Theme_My_Login_Template extends Theme_My_Login_Abstract {
 			get_stylesheet_directory(),
 			get_template_directory() . '/theme-my-login',
 			get_template_directory(),
-			WP_PLUGIN_DIR . '/theme-my-login/templates'
+			THEMEMYLOGIN_PATH . '/templates'
 		) );
 
 		foreach ( (array) $template_names as $template_name ) {

--- a/includes/class-theme-my-login.php
+++ b/includes/class-theme-my-login.php
@@ -168,8 +168,8 @@ class Theme_My_Login extends Theme_My_Login_Abstract {
 	 */
 	public function plugins_loaded() {
 		foreach ( $this->get_option( 'active_modules', array() ) as $module ) {
-			if ( file_exists( WP_PLUGIN_DIR . '/theme-my-login/modules/' . $module ) )
-				include_once( WP_PLUGIN_DIR . '/theme-my-login/modules/' . $module );
+			if ( file_exists( THEMEMYLOGIN_PATH . '/modules/' . $module ) )
+				include_once( THEMEMYLOGIN_PATH . '/modules/' . $module );
 		}
 		do_action_ref_array( 'tml_modules_loaded', array( &$this ) );
 	}
@@ -1015,7 +1015,7 @@ if(typeof wpOnload=='function')wpOnload()
 		elseif ( file_exists( get_template_directory() . '/' . $file ) )
 			$stylesheet = get_template_directory_uri() . '/' . $file;
 		else
-			$stylesheet = plugins_url( '/theme-my-login/' . $file );
+			$stylesheet = plugins_url( $file, dirname( dirname( __FILE__ ) ) );
 		return $stylesheet;
 	}
 

--- a/modules/themed-profiles/themed-profiles.php
+++ b/modules/themed-profiles/themed-profiles.php
@@ -202,7 +202,7 @@ class Theme_My_Login_Themed_Profiles extends Theme_My_Login_Abstract {
 	 * @access public
 	 */
 	public function wp_enqueue_scripts() {
-		wp_enqueue_script( 'tml-themed-profiles', plugins_url( 'theme-my-login/modules/themed-profiles/themed-profiles.js' ), array( 'jquery' ) );
+		wp_enqueue_script( 'tml-themed-profiles', plugins_url( 'themed-profiles.js', __FILE__ ), array( 'jquery' ) );
 	}
 
 	/**
@@ -244,7 +244,7 @@ class Theme_My_Login_Themed_Profiles extends Theme_My_Login_Abstract {
 
 		register_admin_color_schemes();
 
-		wp_enqueue_style( 'password-strength', plugins_url( 'theme-my-login/modules/themed-profiles/themed-profiles.css' ) );
+		wp_enqueue_style( 'password-strength', plugins_url( 'themed-profiles.css', __FILE__ ) );
 
 		wp_enqueue_script( 'user-profile' );
 

--- a/theme-my-login.php
+++ b/theme-my-login.php
@@ -14,25 +14,29 @@ Domain Path: /language/
 if ( file_exists( WP_PLUGIN_DIR . '/theme-my-login-custom.php' ) )
 	include_once( WP_PLUGIN_DIR . '/theme-my-login-custom.php' );
 
+if ( ! defined( 'THEMEMYLOGIN_PATH' ) ) {
+	define( 'THEMEMYLOGIN_PATH', dirname( __FILE__ ) );
+}
+
 // Require a few needed files
-require_once( WP_PLUGIN_DIR . '/theme-my-login/includes/class-theme-my-login-common.php' );
-require_once( WP_PLUGIN_DIR . '/theme-my-login/includes/class-theme-my-login-abstract.php' );
-require_once( WP_PLUGIN_DIR . '/theme-my-login/includes/class-theme-my-login.php' );
-require_once( WP_PLUGIN_DIR . '/theme-my-login/includes/class-theme-my-login-template.php' );
-require_once( WP_PLUGIN_DIR . '/theme-my-login/includes/class-theme-my-login-widget.php' );
+require_once( THEMEMYLOGIN_PATH . '/includes/class-theme-my-login-common.php' );
+require_once( THEMEMYLOGIN_PATH . '/includes/class-theme-my-login-abstract.php' );
+require_once( THEMEMYLOGIN_PATH . '/includes/class-theme-my-login.php' );
+require_once( THEMEMYLOGIN_PATH . '/includes/class-theme-my-login-template.php' );
+require_once( THEMEMYLOGIN_PATH . '/includes/class-theme-my-login-widget.php' );
 
 // Instantiate Theme_My_Login singleton
 Theme_My_Login::get_object();
 
 if ( is_admin() ) {
-	require_once( WP_PLUGIN_DIR . '/theme-my-login/admin/class-theme-my-login-admin.php' );
+	require_once( THEMEMYLOGIN_PATH . '/admin/class-theme-my-login-admin.php' );
 
 	// Instantiate Theme_My_Login_Admin singleton
 	Theme_My_Login_Admin::get_object();
 }
 
 if ( is_multisite() ) {
-	require_once( WP_PLUGIN_DIR . '/theme-my-login/includes/class-theme-my-login-ms-signup.php' );
+	require_once( THEMEMYLOGIN_PATH . '/includes/class-theme-my-login-ms-signup.php' );
 
 	// Instantiate Theme_My_Login_MS_Signup singleton
 	Theme_My_Login_MS_Signup::get_object();


### PR DESCRIPTION
While debugging the language issue, I added the plugin to my local test environment using a non-standard path and literally _everything_ broke. I couldn't even activate the plugin because of the errors.

This PR fixes that.
