### PR TITLE
Fixed Log in, Register, Lost Password Button Titles unmodifiable issue

### DIFF
--- a/includes/class-theme-my-login-template.php
+++ b/includes/class-theme-my-login-template.php
@@ -149,24 +149,20 @@ class Theme_My_Login_Template extends Theme_My_Login_Abstract {
 		if ( is_user_logged_in() && 'login' == $action && $action == $this->get_option( 'default_action' ) ) {
 			$title = sprintf( __( 'Welcome, %s', 'theme-my-login' ), wp_get_current_user()->display_name );
 		} else {
-			if ( $page_id = Theme_My_Login::get_page_id( $action ) ) {
-				$title = get_post_field( 'post_title', $page_id );
-			} else {
-				switch ( $action ) {
-					case 'register':
-						$title = __( 'Register', 'theme-my-login' );
-						break;
-					case 'lostpassword':
-					case 'retrievepassword':
-					case 'resetpass':
-					case 'rp':
-						$title = __( 'Lost Password', 'theme-my-login' );
-						break;
-					case 'login':
-					default:
-						$title = __( 'Log In', 'theme-my-login' );
-				}
-			}
+            switch ( $action ) {
+                case 'register':
+                    $title = __( 'Register', 'theme-my-login' );
+                    break;
+                case 'lostpassword':
+                case 'retrievepassword':
+                case 'resetpass':
+                case 'rp':
+                    $title = __( 'Lost Password', 'theme-my-login' );
+                    break;
+                case 'login':
+                default:
+                    $title = __( 'Log In', 'theme-my-login' );
+            }
 		}
 		return apply_filters( 'tml_title', $title, $action );
 	}


### PR DESCRIPTION
Every time button titles get the page's titles. So on translated web sites should have translated title per each page. This is very difficult. And in the code, there's a else part which we can assign custom wordings, and its more useful. 

However as per the `if ( $page_id = Theme_My_Login::get_page_id( $action ) )`  condition it never falls to `else` part to access custom wording. Is there any particular reason why you have that page title assigning for buttons?
