### PR TITLE
Fix strict warning on PHP 7

### DIFF
--- a/includes/class-theme-my-login.php
+++ b/includes/class-theme-my-login.php
@@ -1077,11 +1077,11 @@ if(typeof wpOnload=='function')wpOnload()
 	 * @return object Instance object
 	 */
 	public function load_instance( $args = '' ) {
-		$args['instance'] = count( $this->loaded_instances );
 
 		$instance = new Theme_My_Login_Template( $args );
+		$instance->set_option( 'instance', count( $this->loaded_instances ) );
 
-		if ( $args['instance'] == $this->request_instance ) {
+		if ( $instance->get_option( 'instance' ) === $this->request_instance ) {
 			$instance->set_active();
 			$instance->set_option( 'default_action', $this->request_action );
 		}


### PR DESCRIPTION
Setting $args to a string and then immediately treating it as an array
caused issues on PHP7.

This sets the default to an empty array.

`Warning: Illegal string offset 'instance' in /htdocs/wp-content/plugins/theme-my-login/includes/class-theme-my-login.php on line 1080`
