### PR TITLE
Don't add recaptcha errors when adding a user from wp-admin

### DIFF
--- a/modules/recaptcha/recaptcha.php
+++ b/modules/recaptcha/recaptcha.php
@@ -131,6 +131,11 @@ class Theme_My_Login_Recaptcha extends Theme_My_Login_Abstract {
 	 * @return array Signup parameters
 	 */
 	public function wpmu_validate_signup( $result ) {
+		// Don't add errors if adding a user from wp-admin.
+		if ( is_admin() ) {
+			return $result;
+		}
+
 		$result['errors'] = $this->registration_errors( $result['errors'] );
 		return $result;
 	}


### PR DESCRIPTION
Fixes #83.

This could also be changed to not load any of the recaptcha class when `is_admin()` is true, but I haven't tested that.
