### PR TITLE
Prevent pass-through to `get_bloginfo` for `%siteurl%`

### DIFF
--- a/includes/class-theme-my-login-common.php
+++ b/includes/class-theme-my-login-common.php
@@ -86,6 +86,7 @@ class Theme_My_Login_Common {
 	public static function replace_vars( $input, $user_id = '', $replacements = array() ) {
 		$defaults = array(
 			'%site_url%' => get_bloginfo( 'url' ),
+			'%siteurl%'  => get_bloginfo( 'url' ),
 			'%user_ip%'  => $_SERVER['REMOTE_ADDR']
 		);
 		$replacements = wp_parse_args( $replacements, $defaults );


### PR DESCRIPTION
%site_url% is the correct variable that TML is looking for. %siteurl% gets
passed to get_bloginfo and is a deprecated parameter for that function
which throws a notice. This fixes the help text so the correct
variable is recommended.
