### PR TITLE
Cast request_instance to int

### DIFF
--- a/includes/class-theme-my-login.php
+++ b/includes/class-theme-my-login.php
@@ -1081,7 +1081,7 @@ if(typeof wpOnload=='function')wpOnload()
 		$instance = new Theme_My_Login_Template( $args );
 		$instance->set_option( 'instance', count( $this->loaded_instances ) );
 
-		if ( $instance->get_option( 'instance' ) === $this->request_instance ) {
+		if ( $instance->get_option( 'instance' ) === (int) $this->request_instance ) {
 			$instance->set_active();
 			$instance->set_option( 'default_action', $this->request_action );
 		}


### PR DESCRIPTION
Fixes an issue where the current instance wasn't being set as active.

@jfarthing84 this was caused by the changes we made in https://github.com/jfarthing84/theme-my-login/pull/80

The symptom I was seeing is that errors weren't showing on the login page (e.g. checkemail=confirm when resetting a password)
