### PR TITLE
Remove useless < and > symbols on reset email content

### DIFF
--- a/includes/class-theme-my-login.php
+++ b/includes/class-theme-my-login.php
@@ -1168,7 +1168,7 @@ if(typeof wpOnload=='function')wpOnload()
 		$message .= sprintf( __( 'Username: %s', 'theme-my-login' ), $user_login ) . "\r\n\r\n";
 		$message .= __( 'If this was a mistake, just ignore this email and nothing will happen.', 'theme-my-login' ) . "\r\n\r\n";
 		$message .= __( 'To reset your password, visit the following address:', 'theme-my-login' ) . "\r\n\r\n";
-		$message .= '<' . network_site_url( "wp-login.php?action=rp&key=$key&login=" . rawurlencode( $user_login ), 'login' ) . ">\r\n";
+		$message .= network_site_url( "wp-login.php?action=rp&key=$key&login=" . rawurlencode( $user_login ), 'login' ) . "\r\n";
 
 		if ( is_multisite() ) {
 			$blogname = $GLOBALS['current_site']->site_name;


### PR DESCRIPTION
I receive the reset email content as screenshot below:

![image](https://cloud.githubusercontent.com/assets/1921869/20425397/aef5c4d6-ad7a-11e6-8537-440c8d05feae.png)

You can see the tag <a> with the double link for reset. I fix with the change I suggest you in this email and this is how I receive now the email:

![image](https://cloud.githubusercontent.com/assets/1921869/20425509/2d4687a8-ad7b-11e6-9d71-ab8aa20615c6.png)

it could be great if you can merge this change, in order to fix the email. Thanks :)