### PR TITLE
Cookie Redirection

### DIFF
--- a/modules/custom-redirection/custom-redirection.php
+++ b/modules/custom-redirection/custom-redirection.php
@@ -153,6 +153,33 @@ class Theme_My_Login_Custom_Redirection extends Theme_My_Login_Abstract {
 					$redirect_to
 				);
 				break;
+				
+				case 'cookie' :
+				// Send 'em to the specified Cookie name
+				if(count($_COOKIE) > 0) {
+					//Determine if cookies turned on
+				$cookie = $redirection["{$type}_cookie"];
+				
+				if (isset($_COOKIE["{$cookie}"])){
+					//Determine if cookie by that name is set
+				$redirect_to = $_COOKIE["{$cookie}"];
+				
+				// Allow a few user specific variables
+				$redirect_to = str_replace(
+					array(
+						'%user_id%',
+						'%user_nicename%'
+					),
+					array(
+						$user->ID,
+						$user->user_nicename
+					),
+					$redirect_to
+				);
+				
+				}
+				}
+				break;
 		}
 
 		// Make sure $redirect_to isn't empty


### PR DESCRIPTION
I'm working on a site where we want the user to return to the last page they visited after logging in. 
To do this I set a cookie in any pages a user might visit before logging in. 
I added an option in the admin under the login option that you can set a cookie name use as a redirection. Please check the custom redirection admin file the switch case. If no cookie by that name is set or cookies are not on, use default.