### PR TITLE
There are a few reports of emails not being translated with WPML:

### DIFF
--- a/includes/class-theme-my-login-abstract.php
+++ b/includes/class-theme-my-login-abstract.php
@@ -112,6 +112,11 @@ abstract class Theme_My_Login_Abstract {
 		$options = wp_parse_args( $options, $this->options );
 
 		$this->options = $options;
+
+		// Re-read options after plugins are loaded so WPML can translate them.
+		if ( defined( 'ICL_SITEPRESS_VERSION' ) ) {
+			add_action( 'plugins_loaded', array( $this, 'load_options' ), 12 );
+		}
 	}
 
 	/**


### PR DESCRIPTION
We found the problem to be the following:

- TML is loading options from the database too early.
- In fact, so early that WPML hasn't had time to add its hooks for translation.
- Instead of changing the loading order logic, its easier to re-read options before sending an email.
- This will cause strings to be translated correctly.

Fixes #123