### PR TITLE
Feature: Allow custom redirects with exceptions.

### DIFF
--- a/languages/theme-my-login.pot
+++ b/languages/theme-my-login.pot
@@ -793,7 +793,7 @@ msgid "Log in"
 msgstr ""
 
 #: modules/custom-redirection/admin/custom-redirection-admin.php:168
-#: modules/custom-redirection/admin/custom-redirection-admin.php:182
+#: modules/custom-redirection/admin/custom-redirection-admin.php:184
 msgid "Default"
 msgstr ""
 
@@ -803,7 +803,7 @@ msgid ""
 msgstr ""
 
 #: modules/custom-redirection/admin/custom-redirection-admin.php:171
-#: modules/custom-redirection/admin/custom-redirection-admin.php:185
+#: modules/custom-redirection/admin/custom-redirection-admin.php:187
 msgid "Referer"
 msgstr ""
 
@@ -814,23 +814,30 @@ msgid ""
 msgstr ""
 
 #: modules/custom-redirection/admin/custom-redirection-admin.php:176
-#: modules/custom-redirection/admin/custom-redirection-admin.php:190
+#: modules/custom-redirection/admin/custom-redirection-admin.php:192
 msgid ""
 "Check this option to send the user to a custom location, specified by the "
 "textbox above."
 msgstr ""
 
-#: modules/custom-redirection/admin/custom-redirection-admin.php:180
+#: modules/custom-redirection/admin/custom-redirection-admin.php:178
+#: modules/custom-redirection/admin/custom-redirection-admin.php:194
+msgid ""
+"If you would like certain URLs to override the custom location, enter those "
+"above, separated by a line break."
+msgstr ""
+
+#: modules/custom-redirection/admin/custom-redirection-admin.php:182
 msgid "Log out"
 msgstr ""
 
-#: modules/custom-redirection/admin/custom-redirection-admin.php:183
+#: modules/custom-redirection/admin/custom-redirection-admin.php:185
 msgid ""
 "Check this option to send the user to the log in page, displaying a message "
 "that they have successfully logged out."
 msgstr ""
 
-#: modules/custom-redirection/admin/custom-redirection-admin.php:186
+#: modules/custom-redirection/admin/custom-redirection-admin.php:188
 msgid ""
 "Check this option to send the user back to the page they were visiting "
 "before logging out. (Note: If the previous page being visited was an admin "

--- a/modules/custom-redirection/admin/custom-redirection-admin.php
+++ b/modules/custom-redirection/admin/custom-redirection-admin.php
@@ -174,6 +174,8 @@ class Theme_My_Login_Custom_Redirection_Admin extends Theme_My_Login_Abstract {
 					<input name="<?php echo $this->options_key; ?>[<?php echo $role; ?>][login_type]" type="radio" id="<?php echo $this->options_key; ?>_<?php echo $role; ?>_login_type_custom" value="custom"<?php checked( 'custom', $this->get_option( array( $role, 'login_type' ) ) ); ?> />
 					<input name="<?php echo $this->options_key; ?>[<?php echo $role; ?>][login_url]" type="text" id="<?php echo $this->options_key; ?>_<?php echo $role; ?>_login_url" value="<?php echo $this->get_option( array( $role, 'login_url' ) ); ?>" class="regular-text" />
 					<p class="description"><?php _e( 'Check this option to send the user to a custom location, specified by the textbox above.', 'theme-my-login' ); ?></p>
+                    <textarea name="<?php echo $this->options_key; ?>[<?php echo $role; ?>][login_url_referers]" id="<?php echo $this->options_key; ?>_<?php echo $role; ?>_login_url_referers" class="regular-text"><?php echo $this->get_option( array( $role, 'login_url_referers' ) ); ?></textarea>
+                    <p class="description"><?php _e( 'If you would like certain URLs to override the custom location, enter those above, separated by a line break.', 'theme-my-login' ); ?></p>
 				</td>
 			</tr>
 			<tr valign="top">
@@ -188,6 +190,8 @@ class Theme_My_Login_Custom_Redirection_Admin extends Theme_My_Login_Abstract {
 					<input name="<?php echo $this->options_key; ?>[<?php echo $role; ?>][logout_type]" type="radio" id="<?php echo $this->options_key; ?>_<?php echo $role; ?>_logout_type_custom" value="custom"<?php checked( 'custom', $this->get_option( array( $role, 'logout_type' ) ) ); ?> />
 					<input name="<?php echo $this->options_key; ?>[<?php echo $role; ?>][logout_url]" type="text" id="<?php echo $this->options_key; ?>_<?php echo $role; ?>_logout_url" value="<?php echo $this->get_option( array( $role, 'logout_url' ) ); ?>" class="regular-text" />
 					<p class="description"><?php _e( 'Check this option to send the user to a custom location, specified by the textbox above.', 'theme-my-login' ); ?></p>
+                    <textarea name="<?php echo $this->options_key; ?>[<?php echo $role; ?>][logout_url_referers]" id="<?php echo $this->options_key; ?>_<?php echo $role; ?>_logout_url_referers" class="regular-text"><?php echo $this->get_option( array( $role, 'logout_url_referers' ) ); ?></textarea>
+                    <p class="description"><?php _e( 'If you would like certain URLs to override the custom location, enter those above, separated by a line break.', 'theme-my-login' ); ?></p>
 				</td>
 			</tr>
 		</table>

--- a/modules/custom-redirection/custom-redirection.php
+++ b/modules/custom-redirection/custom-redirection.php
@@ -139,6 +139,25 @@ class Theme_My_Login_Custom_Redirection extends Theme_My_Login_Abstract {
 			case 'custom' :
 				// Send 'em to the specified URL
 				$redirect_to = $redirection["{$type}_url"];
+				
+				// Check if our URL is in list of special exceptions
+        // If so, we will redirect back to the same page once logged in
+				if( ! empty( $redirection["{$type}_url_referers"] ) ) {
+
+				  // split value by newlines
+				  $custom_referers = preg_split('/\r\n|[\r\n]/', $redirection["{$type}_url_referers"] );
+				  $referer = wp_get_referer();
+
+				  // Check if the string
+				  foreach( $custom_referers as $special_url ) {
+
+				    if( $referer == $special_url || $referer == home_url() . $special_url ) {
+              $redirect_to = $special_url;
+              break;
+            }
+          }
+
+        }
 
 				// Allow a few user specific variables
 				$redirect_to = str_replace(


### PR DESCRIPTION
I love using Theme My Login to clean up my users' login experience. In many cases, I'd like a page to show login credentials, and for the user to return to this page when logging in, similar to the 'referer' setting for custom redirection.

However, this functionality breaks anytime a user needs to reset a password. At that point, when they log in, a user is directed to their profile page, which I'd like to avoid at all costs.

This additional setting allows an admin to specify a default page for most traffic, and then create a list of URLs which should act as referers.

This is still somewhat untested. I've seen this work well for logging in, have not tried logging out yet. Open to suggestions, certainly.