### PR TITLE
Suppress empty username/password errors if no POST has occurred and e…

### DIFF
--- a/src/includes/actions.php
+++ b/src/includes/actions.php
@@ -497,9 +497,11 @@ function tml_login_handler() {
 		$errors = new WP_Error;
 	}
 
-	if ( empty( $_POST ) && $errors->get_error_codes() === array( 'empty_username', 'empty_password' ) ) {
-		$errors = new WP_Error;
-	}
+    $error_codes = $errors->get_error_codes();
+
+    if ( empty( $_POST ) && ( $error_codes === array( 'empty_username', 'empty_password' ) || $error_codes === array( 'empty_username' ) || $error_codes === array( 'empty_password' ) )  ) {
+        $errors = new WP_Error;
+    }
 
 	// Some parts of this script use the main login form to display a message
 	if ( isset( $_GET['loggedout'] ) && true == $_GET['loggedout'] ) {


### PR DESCRIPTION
…ither username is empty or password is empty

Actually in our case only empty_password error was present. Here is the debug output:
```bash
Array 
( 
    [$code] => empty_password 
)
```
This fix will make it work when either empty_username or empty_password is present. 