### PR TITLE
Fix conflit with elementor loading to early causing console error 

### DIFF
--- a/src/includes/hooks.php
+++ b/src/includes/hooks.php
@@ -35,8 +35,8 @@ add_action( 'wp', 'tml_remove_default_actions_and_filters' );
 add_action( 'template_redirect',  'tml_action_handler',   0 );
 add_action( 'wp_enqueue_scripts', 'tml_enqueue_styles',  10 );
 add_action( 'wp_enqueue_scripts', 'tml_enqueue_scripts', 10 );
-add_action( 'wp_head',            'tml_do_login_head',   10 );
-add_action( 'wp_footer',          'tml_do_login_footer', 10 );
+add_action( 'wp_head',            'tml_do_login_head',   100 );
+add_action( 'wp_footer',          'tml_do_login_footer', 100 );
 
 // Registration
 add_action( 'pre_user_login',    'tml_set_user_login'        );


### PR DESCRIPTION
Fixes the loading of elementor that was causing elementor not to load on pages from theme-my-login like login/dashboard/lostpassword/register because it was loading to early before elementor fires causing the following error on console:
frontend.min.js?ver=3.29.2:2 Uncaught ReferenceError: elementorFrontendConfig is not defined